### PR TITLE
Add basic file input support

### DIFF
--- a/demod.c
+++ b/demod.c
@@ -15,12 +15,12 @@
 #include <time.h>
 
 // Network
-#include <sys/socket.h> 
-#include <arpa/inet.h> 
-#include <netinet/in.h> 
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
 
 // and link the following with mdc_decode.c on compile!
-#include "fsync_decode.h" 
+#include "fsync_decode.h"
 #include "mdc_decode.h"
 
 #define UDPPORT 9101
@@ -29,19 +29,19 @@
 
 void sendJsonUDP(char *message) {
 
-    int sockfd; 
-    struct sockaddr_in servaddr; 
-    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) { 
-        fprintf(stderr, "Socket creation error\n"); 
-        return; 
-    } 
-    memset(&servaddr, 0, sizeof(servaddr)); 
-    servaddr.sin_family = AF_INET; 
-    servaddr.sin_port = htons(UDPPORT); 
-    servaddr.sin_addr.s_addr = INADDR_ANY; 
-    int n, len; 
-    sendto(sockfd, message, strlen(message), MSG_CONFIRM, (const struct sockaddr *) &servaddr, sizeof(servaddr)); 
-    close(sockfd); 
+    int sockfd;
+    struct sockaddr_in servaddr;
+    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) {
+        fprintf(stderr, "Socket creation error\n");
+        return;
+    }
+    memset(&servaddr, 0, sizeof(servaddr));
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_port = htons(UDPPORT);
+    servaddr.sin_addr.s_addr = INADDR_ANY;
+    int n, len;
+    sendto(sockfd, message, strlen(message), MSG_CONFIRM, (const struct sockaddr *) &servaddr, sizeof(servaddr));
+    close(sockfd);
     return;
 
 }
@@ -88,13 +88,13 @@ void mdcCallBack(int numFrames, unsigned char op, unsigned char arg, unsigned sh
                                          "\"ex2\":\"%02x\","\
                                          "\"ex3\":\"%02x\"}", (int)time(NULL), op, arg, unitID,extra0, \
                                          extra1, extra2, extra3);
-                                         
+
     fprintf(stdout, "%s\n", json_buffer);
     sendJsonUDP(json_buffer);
 }
 
 
-static void read_input(int inputflag) {
+static void read_input(int inputflag, char *pathname) {
 
     // General
     int sample_rate = 8000;
@@ -110,35 +110,35 @@ static void read_input(int inputflag) {
     pa_simple *s;
     pa_sample_spec ss;
 
-    
-    // Fleetsync
-    fsync_decoder_t *f_decoder; 
-    f_decoder = fsync_decoder_new(sample_rate); 
-    fsync_decoder_set_callback(f_decoder, fsyncCallBack, 0);
-    int f_result; 
-    
-    // MDC1200 
-    mdc_decoder_t *m_decoder; 
-    unsigned char op, arg, extra0, extra1, extra2, extra3; 
-    unsigned short unitID;
-    m_decoder = mdc_decoder_new(sample_rate);  
-    mdc_decoder_set_callback(m_decoder, mdcCallBack, 0);
-    int m_result; 
 
-    
+    // Fleetsync
+    fsync_decoder_t *f_decoder;
+    f_decoder = fsync_decoder_new(sample_rate);
+    fsync_decoder_set_callback(f_decoder, fsyncCallBack, 0);
+    int f_result;
+
+    // MDC1200
+    mdc_decoder_t *m_decoder;
+    unsigned char op, arg, extra0, extra1, extra2, extra3;
+    unsigned short unitID;
+    m_decoder = mdc_decoder_new(sample_rate);
+    mdc_decoder_set_callback(m_decoder, mdcCallBack, 0);
+    int m_result;
+
+
     // Pulse init if not reading raw input
     if (inputflag == 0)
         {
         ss.format = PA_SAMPLE_U8;
         ss.channels = 1;
         ss.rate = sample_rate;
-    // Try to create the recording stream 
+    // Try to create the recording stream
         if (!(s = pa_simple_new(NULL, "Fleetsync/MDC1200 Decoder", PA_STREAM_RECORD, NULL, "record", &ss, NULL, NULL, &error))) {
             fprintf(stderr, __FILE__": Pulseaudio Init Failed: %s\n", pa_strerror(error));
             exit(4);
             }
         }
-    
+
     // Decoder main routine
         fprintf(stderr, "Decoders Initialized\n");
         switch(inputflag)
@@ -149,46 +149,70 @@ static void read_input(int inputflag) {
             case 1:
                 fprintf(stderr, "Reading RAW samples from STDIN\n");
                 break;
+            case 2:
+              fprintf(stderr, "Reading RAW file from pathname\n");
             }
 
-    // Loop over input
-        for (;;)
-            {            
-            if (inputflag == 0)
-                {
-                    if (pa_simple_read(s, buffer, sizeof(buffer), &error) < 0) 
-                        {
-                        fprintf(stderr, __FILE__": read() failed: %s\n", strerror(errno));
-                        exit(4);
-                        }
-                }
-                        
-            else   
-                {     
-                    i = read(fd, buffer, sizeof(buffer));
-                }
+    // Loop over finite file if reading file
+    if (inputflag == 2) {
+      FILE *fp = fopen(pathname, "r");
+      if (!fp) {
+        fprintf(stderr, "File open failed\n");
+        exit(EXIT_FAILURE);
+      }
+      while (1 == fread(buffer, sizeof(buffer), 1, fp)) {
+        f_result = fsync_decoder_process_samples(f_decoder, buffer, sizeof(buffer));
+        m_result = mdc_decoder_process_samples(m_decoder, buffer, sizeof(buffer));
+        if (f_result == -1) {
+          fprintf(stderr, "Fleetsync Decoder Error\n");
+          exit(1);
+        }
+        if (m_result == -1) {
+          fprintf(stderr, "MDC Decoder Error\n");
+          exit(1);
+        }
+      }
 
-                    // Magic time
-                    // Send buffer to decoders until callback fires
-                    // Only care about catching -1 for errors, other return values dont really matter here
-                    // Decoders will fire the callbacks when a message is decoded
-                    
-                    f_result = fsync_decoder_process_samples(f_decoder, buffer, sizeof(buffer));
-                    m_result = mdc_decoder_process_samples(m_decoder, buffer, sizeof(buffer));
-                    memmove(fbuf, fbuf+fbuf_cnt-overlap, overlap*sizeof(fbuf[0]));
-                    fbuf_cnt = overlap;
-                    if (f_result == -1)
-                        {
-                        fprintf(stderr,"Fleetsync Decoder Error\n");
-                        exit(1);
-                        }
-                    if (m_result == -1)
-                        {
-                        fprintf(stderr,"MDC Decoder Error\n");
-                        exit(1);
-                        }
-                    
-            }
+    } else if (inputflag < 2) {
+      // Loop over input
+          for (;;)
+              {
+              if (inputflag == 0)
+                  {
+                      if (pa_simple_read(s, buffer, sizeof(buffer), &error) < 0)
+                          {
+                          fprintf(stderr, __FILE__": read() failed: %s\n", strerror(errno));
+                          exit(4);
+                          }
+                  }
+
+              else
+                  {
+                      i = read(fd, buffer, sizeof(buffer));
+                  }
+
+                      // Magic time
+                      // Send buffer to decoders until callback fires
+                      // Only care about catching -1 for errors, other return values dont really matter here
+                      // Decoders will fire the callbacks when a message is decoded
+
+                      f_result = fsync_decoder_process_samples(f_decoder, buffer, sizeof(buffer));
+                      m_result = mdc_decoder_process_samples(m_decoder, buffer, sizeof(buffer));
+                      memmove(fbuf, fbuf+fbuf_cnt-overlap, overlap*sizeof(fbuf[0]));
+                      fbuf_cnt = overlap;
+                      if (f_result == -1)
+                          {
+                          fprintf(stderr,"Fleetsync Decoder Error\n");
+                          exit(1);
+                          }
+                      if (m_result == -1)
+                          {
+                          fprintf(stderr,"MDC Decoder Error\n");
+                          exit(1);
+                          }
+
+              }
+    }
 }
 
 
@@ -197,43 +221,44 @@ static void read_input(int inputflag) {
 
 int main(int argc, char *argv[]) {
 
-    fprintf(stderr, "\n\n\t              Fleetsync / MDC1200 Decoder for Linux               \n");
-    fprintf(stderr, "\t         Run with '-' flag option to use STDIN for input              \n");
-    fprintf(stderr, "\t        STDIN input MUST be RAW, MONO 8 bit unsigned integer          \n");
-    fprintf(stderr, "\t                  with a sample rate of 8000hz                       \n\n");
-    fprintf(stderr, "\t      ** NOTE ** - Proper input volume is necessary for decoding      \n");
-    fprintf(stderr, "\t                   if using system audio input                        \n");
-    fprintf(stderr, "\t----------------------------------------------------------------------\n\n");
-    fprintf(stderr, "\t  If using SDR (rtlsdr), pipe to SoX using the following settings:    \n");
-    fprintf(stderr, "\t  rtl_fm -f (freq) -s 24000 -p (ppm) -g (gain) |                      \n");
-    fprintf(stderr, "\t  sox -traw -r24000 -e signed-integer -L -b16 -c1 -V1 -v2 - -traw \\   \n");
-    fprintf(stderr, "\t  -e unsigned-integer -b8 -c1 -r8000 - highpass 200 lowpass 4000 |    \n");
-    fprintf(stderr, "\t  ./demod -                                                           \n\n\n");
+    fprintf(stderr, "\n\n\t              Fleetsync / MDC1200 Decoder for Linux                   \n\n");
+    fprintf(stderr,     "\t                Run with no   flag for audio input.                   \n");
+    fprintf(stderr,     "\t                Run with '-'  flag for STDIN as input.                \n");
+    fprintf(stderr,     "\t                Run with '-f' flag for file input.                    \n\n");
+    fprintf(stderr,     "\t    STDIN or file input MUST be RAW, MONO 8 bit unsigned integer      \n");
+    fprintf(stderr,     "\t                  with a sample rate of 8000hz                        \n\n");
+    fprintf(stderr,     "\t      ** NOTE ** - Proper input volume is necessary for decoding      \n");
+    fprintf(stderr,     "\t                   if using system audio input                        \n\n");
+    fprintf(stderr,     "\t----------------------------------------------------------------------\n\n");
+    fprintf(stderr,     "\t  If using SDR (rtlsdr), pipe to SoX using the following settings:    \n");
+    fprintf(stderr,     "\t  rtl_fm -f (freq) -s 24000 -p (ppm) -g (gain) |                      \n");
+    fprintf(stderr,     "\t  sox -traw -r24000 -e signed-integer -L -b16 -c1 -V1 -v2 - -traw \\  \n");
+    fprintf(stderr,     "\t  -e unsigned-integer -b8 -c1 -r8000 - highpass 200 lowpass 4000 |    \n");
+    fprintf(stderr,     "\t  ./demod -                                                           \n\n\n");
 
-    // flag 0: Audio, 1: Raw via STDIN, 0 by default
+    // flag 0: audio input (default)
+    // flag 1: raw via STDIN
+    // flag 2: raw via pathname
     int inputflag = 0;
+    char *pathname;
 
-    // Catch wrong # of arguments
-    if (argc > 2)
-        {
-        fprintf(stderr, "\n Error - Improper number of arguments \n");
+    if (argc == 1) {
+      inputflag = 0;
+    } else if (argc == 2 && strcmp(argv[1], "-") == 0) {
+      inputflag = 1;
+    } else if (argc == 3 && strcmp(argv[1], "-f") == 0) {
+      inputflag = 2;
+      pathname = malloc(strlen(argv[2]) + 1);
+      strcpy(pathname, argv[2]);
+    } else {
+      fprintf(stderr, "Invalid input\n");
+      exit(EXIT_FAILURE);
+    }
 
-        exit(-1);
-        }
-
-    // Check arguments for "-" for raw input 
-    
-    if (argc == 2)
-        {
-        if (strcmp(argv[1], "-") == 0) 
-            {inputflag = 1;}
-        }
-
-    read_input(inputflag);
+    read_input(inputflag, pathname);
 
 
     exit(0);
 
-    
-}
 
+}


### PR DESCRIPTION
As it says on the tin, this patch provides basic file input support.

The software as-is was clearly meant for handling piped live audio, but I'd like for it to be able to also handle files for recorded audio analysis.

I intentionally tried to not touch most of the existing structure as possible for the time being, only adding the bare minimum for `argv` wrangling and pathname handling in `read_input()`.

I also intentionally handled the file case separately instead of tucking it inside the `for (;;)` loop since I'd like to be able to gain relative file timestamp support in the future instead of spitting out local timestamps. This was the basis for writing pathname input support as opposed to just shimming up piping a file into existing stdin support.

Before I do more work, there's a little bit of housekeeping and such I'd like to tend to, which I will submit as issues for further conversation.

I apologize for any mistakes in advance, I haven't touched c in a long while. I'll also note that most of what I just added I would consider hacky - ideally in the near future using getopt/argp instead of rolling our own input parsing, better management of errors and exits, etc.

Thank you for your consideration.